### PR TITLE
removes settingslogic (env_config) steps

### DIFF
--- a/roles/backend_config/tasks/main.yml
+++ b/roles/backend_config/tasks/main.yml
@@ -10,24 +10,6 @@
            --without test development --binstubs --deployment"
   tags: [be_deploy, bundle]
 
-# SettingsLogic Users: Uncomment this block and comment/remove the secrets.yml as needed.
-# Untested: Figaro users: uncomment & swap env_config.yml out for application.yml
-
-# - name: Ensure env_config.yml file present
-#  stat: path={{ be_app_path }}/config/env_config.yml
-#  register: env_config_file
-#  tags: [be_deploy]
-
-# - name: Ask for env_config.yml
-#  debug: msg="You've got to upload env_config.yml to {{be_app_path}}/config to continue"
-#  when: env_config_file.stat.exists != true
-#  tags: [be_deploy]
-
-# - name: Wait one day for env_config.yml to get put on the server
-#  wait_for: path={{be_app_path}}/config/env_config.yml state=present timeout=86400
-#  when: env_config_file.stat.exists != true
-#  tags: [be_deploy]
-
 - name: Ensure secrets.yml file present
   stat: path={{ be_app_path }}/config/secrets.yml
   register: secrets_file

--- a/roles/backend_config/tasks/main.yml
+++ b/roles/backend_config/tasks/main.yml
@@ -10,20 +10,23 @@
            --without test development --binstubs --deployment"
   tags: [be_deploy, bundle]
 
-- name: Ensure env_config.yml file present
-  stat: path={{ be_app_path }}/config/env_config.yml
-  register: env_config_file
-  tags: [be_deploy]
+# SettingsLogic Users: Uncomment this block and comment/remove the secrets.yml as needed.
+# Untested: Figaro users: uncomment & swap env_config.yml out for application.yml
 
-- name: Ask for env_config.yml
-  debug: msg="You've got to upload env_config.yml to {{be_app_path}}/config to continue"
-  when: env_config_file.stat.exists != true
-  tags: [be_deploy]
+# - name: Ensure env_config.yml file present
+#  stat: path={{ be_app_path }}/config/env_config.yml
+#  register: env_config_file
+#  tags: [be_deploy]
 
-- name: Wait one day for env_config.yml to get put on the server
-  wait_for: path={{be_app_path}}/config/env_config.yml state=present timeout=86400
-  when: env_config_file.stat.exists != true
-  tags: [be_deploy]
+# - name: Ask for env_config.yml
+#  debug: msg="You've got to upload env_config.yml to {{be_app_path}}/config to continue"
+#  when: env_config_file.stat.exists != true
+#  tags: [be_deploy]
+
+# - name: Wait one day for env_config.yml to get put on the server
+#  wait_for: path={{be_app_path}}/config/env_config.yml state=present timeout=86400
+#  when: env_config_file.stat.exists != true
+#  tags: [be_deploy]
 
 - name: Ensure secrets.yml file present
   stat: path={{ be_app_path }}/config/secrets.yml


### PR DESCRIPTION
There’s no reason to be using settingslogic (or figaro) in Rails 4.1 or beyond, which was released April 8, 2014. I do think it's worth leaving in place but commented, but having to ssh in, create an empty and useless file in order to continue installation seems like it's unnecessary for almost any app going forward.