### PR TITLE
Fix typo in apt-get update

### DIFF
--- a/roles/general/tasks/main.yml
+++ b/roles/general/tasks/main.yml
@@ -1,4 +1,4 @@
-- name: apt-get udpate upgrade
+- name: apt-get update upgrade
   apt: update_cache=yes  upgrade=safe
   tags: [update, upgrade]
 


### PR DESCRIPTION
## Why?
There was a typo in the command that updates APT's list of packages.

## What changed?
The typo was fixed.