### PR TITLE
Fix installer error

### DIFF
--- a/lib/tape/installer.rb
+++ b/lib/tape/installer.rb
@@ -1,3 +1,4 @@
+require 'pathname'
 module TapeBoxer
   class Installer < ExecutionModule
     TapeBoxer.register_module :installer, self
@@ -102,7 +103,7 @@ module TapeBoxer
     end
 
     def mkdir(name)
-      print "#{Pathname.new(name).basename}: "
+      print "#{::Pathname.new(name).basename}: "
       begin
         FileUtils.mkdir name
         success
@@ -115,7 +116,7 @@ module TapeBoxer
     end
 
     def copy_example(file, cp_file)
-      print "#{Pathname.new(cp_file).basename}: "
+      print "#{::Pathname.new(cp_file).basename}: "
       begin
         if File.exist?("#{cp_file}")
           exists


### PR DESCRIPTION
### Why?

I tried updating glen raven to 1.3, by running `bundle update taperole` then `tape installer install` (as seen in the readme). The second command resulted in this:

````
/Users/dkniffin/.rbenv/versions/2.1.7/lib/ruby/gems/2.1.0/gems/taperole-1.3.0/lib/tape/installer.rb:105:in `mkdir': uninitialized constant TapeBoxer::Installer::Pathname (NameError)
````

### What changed?

Since we're inside a module (`TapeBoxer`) here, we have to prepend `::` to access global namespace classes.