### PR TITLE
Neutral Deployer Pronouns

### DIFF
--- a/lib/tape/ansible_runner.rb
+++ b/lib/tape/ansible_runner.rb
@@ -23,7 +23,7 @@ class AnsibleRunner < ExecutionModule
          "Restarts Nginx"
   action :configure_deployer_user,
          proc { ansible '-t deployer' },
-         "Ensures the deployer user is present and configures his SSH keys"
+         "Ensures the deployer user is present and configures its SSH keys"
   action :reset_db,
          proc { ansible '-t db_reset -e force_db_reset=true' },
          "wipes and re-seeds the DB"

--- a/roles/deployer_user/tasks/main.yml
+++ b/roles/deployer_user/tasks/main.yml
@@ -12,7 +12,7 @@
 # It's possible for the deployer's homedir to get created on accident by
 # a deploy script or something getting run before this.  This just ensures
 # the env is sane moving forward
-- name: Ensure deployer user owns his own homedir
+- name: Ensure deployer user owns its own homedir
   file: path=/home/deployer state=directory owner=deployer
 
 - include: keys.yml


### PR DESCRIPTION
# Why?
+ The `deployer` user seems like more of a non-gendered entity. Language was consistently general, except in two places.
+ I wanted to PR to `taperole` so I can know what greatness tastes like

# What Changed?
+ Replaced "his" with "its" where appropriate