### PR TITLE
Run Custom Ansible Playbooks

### DIFF
--- a/bin/tape
+++ b/bin/tape
@@ -27,6 +27,11 @@ opt_parser = OptionParser.new do |opts|
       options.port = p
     end
 
+  opts.on('-bBOOK', "--book=PLAYBOOK",
+    String, "A custom playbook to run") do |p|
+      options.book = p
+    end
+
   opts.on("-h", "--help", "Show this help") do
     STDERR.puts opts
     exit 0

--- a/lib/tape/ansible_runner.rb
+++ b/lib/tape/ansible_runner.rb
@@ -43,6 +43,9 @@ class AnsibleRunner < ExecutionModule
   action :everything,
          proc { valid_preconfigs ? ansible : puts("Not a Rails or JS app") },
          "This does it all."
+  action :playbook,
+         proc { ansible_custom_playbook },
+         "Run a custom playbook"
 
   def initialize(*args)
     super
@@ -81,6 +84,10 @@ class AnsibleRunner < ExecutionModule
 
   def ansible_deploy(cmd_str = '')
     exec_ansible("#{tapefiles_dir}/deploy.yml", cmd_str)
+  end
+
+  def ansible_custom_playbook(cmd_str = '')
+    exec_ansible("#{tapefiles_dir}/#{opts.book}", cmd_str)
   end
 
   def exec_ansible(playbook, args)


### PR DESCRIPTION
# Why?
+ Currently Tape only supports a few built-in Ansible playbooks (`omnibox.yml`, `deploy.yml`) but does not allow for running arbitrary playbooks created for a specific project. 

# What Changed?
+ Added the `tape ansible playbook` command and the `--book=PLAYBOOK-PATH` option, which, when used in conjunction, will run a given YML file as a playbook with Tape configuration.

**NOTE**: I've been out of the Ruby game for a while and have no experience working with `optparse`. Ideally, the command could be run as `tape ansible playbook [PLAYBOOK-PATH]` but I don't know how to capture the arguments appropriately.