### PR TITLE
Add ability to run rake tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ This command runs all Ansible roles specified in the deploy.yml playbook.
 To run ad-hoc rake tasks, you can use the following:
 
 ```
-take ansible rake --task users:rank
+tape ansible rake --task users:rank
 ```
 
 ## Slack integration

--- a/README.md
+++ b/README.md
@@ -256,6 +256,14 @@ This will git pull the latest changes from the tracking branch you specified and
 
 This command runs all Ansible roles specified in the deploy.yml playbook.
 
+### Rake tasks
+
+To run ad-hoc rake tasks, you can use the following:
+
+```
+take ansible rake --task users:rank
+```
+
 ## Slack integration
 
 Tape includes built-in support for posting messages to slack at the beginning and end of deployments.

--- a/bin/tape
+++ b/bin/tape
@@ -61,6 +61,10 @@ opt_parser = OptionParser.new do |opts|
       opts.separator "    #{action.name}: #{action.description}"
     end
   end
+
+  opts.on("--task [TASK]", String, "name of the rake task to execute") do |t|
+    options.task = t
+  end
 end
 
 

--- a/lib/tape/ansible_runner.rb
+++ b/lib/tape/ansible_runner.rb
@@ -46,6 +46,9 @@ class AnsibleRunner < ExecutionModule
   action :playbook,
          proc { ansible_custom_playbook },
          "Run a custom playbook"
+  action :rake,
+         proc { ansible_rake_task },
+         "Run a rake task"
 
   def initialize(*args)
     super
@@ -88,6 +91,10 @@ class AnsibleRunner < ExecutionModule
 
   def ansible_custom_playbook(cmd_str = '')
     exec_ansible("#{tapefiles_dir}/#{opts.book}", cmd_str)
+  end
+
+  def ansible_rake_task
+    exec_ansible("#{tapefiles_dir}/rake.yml", "--extra-vars \"task=#{opts.task}\"")
   end
 
   def exec_ansible(playbook, args)

--- a/lib/tape/installer.rb
+++ b/lib/tape/installer.rb
@@ -49,33 +49,21 @@ module TapeBoxer
     end
 
     def copy_static_app_examples
-      copy_example(
-        'templates/static_html/omnibox.example.yml',
-        "#{tapefiles_dir}/omnibox.yml"
-      )
-      copy_example(
-        'templates/static_html/deploy.example.yml',
-        "#{tapefiles_dir}/deploy.yml"
-      )
-      copy_example(
-        'templates/static_html/tape_vars.example.yml',
-        "#{tapefiles_dir}/tape_vars.yml"
-      )
+      ["omnibox", "deploy", 'tape_vars', 'rake'].each do |base_filename|
+        copy_example(
+          "templates/static_html/#{base_filename}.example.yml",
+          "#{tapefiles_dir}/#{base_filename}.yml"
+        )
+      end
     end
 
     def copy_basic_examples
-      copy_example(
-        'templates/base/omnibox.example.yml',
-        "#{tapefiles_dir}/omnibox.yml"
-      )
-      copy_example(
-        'templates/base/deploy.example.yml',
-        "#{tapefiles_dir}/deploy.yml"
-      )
-      copy_example(
-        'templates/base/tape_vars.example.yml',
-        "#{tapefiles_dir}/tape_vars.yml"
-      )
+      ["omnibox", "deploy", 'tape_vars', 'rake'].each do |base_filename|
+        copy_example(
+          "templates/static_html/#{base_filename}.example.yml",
+          "#{tapefiles_dir}/#{base_filename}.yml"
+        )
+      end
     end
 
     def uninstall

--- a/lib/tape/installer.rb
+++ b/lib/tape/installer.rb
@@ -49,7 +49,7 @@ module TapeBoxer
     end
 
     def copy_static_app_examples
-      ["omnibox", "deploy", 'tape_vars', 'rake'].each do |base_filename|
+      ["omnibox", "deploy", 'tape_vars'].each do |base_filename|
         copy_example(
           "templates/static_html/#{base_filename}.example.yml",
           "#{tapefiles_dir}/#{base_filename}.yml"
@@ -60,7 +60,7 @@ module TapeBoxer
     def copy_basic_examples
       ["omnibox", "deploy", 'tape_vars', 'rake'].each do |base_filename|
         copy_example(
-          "templates/static_html/#{base_filename}.example.yml",
+          "templates/base/#{base_filename}.example.yml",
           "#{tapefiles_dir}/#{base_filename}.yml"
         )
       end

--- a/lib/tape/installer.rb
+++ b/lib/tape/installer.rb
@@ -70,6 +70,7 @@ module TapeBoxer
       rm "#{tapefiles_dir}/omnibox.yml"
       rm "#{tapefiles_dir}/deploy.yml"
       rm "#{tapefiles_dir}/tape_vars.yml"
+      rm "#{tapefiles_dir}/rake.yml"
       rm "#{tapefiles_dir}/roles"
       rm "#{tapefiles_dir}/hosts"
       rm "#{tapefiles_dir}/dev_keys"
@@ -78,7 +79,7 @@ module TapeBoxer
 
     def rm(file)
       print 'Deleting '.red
-      FileUtils.rm_r "#{local_dir}/#{file}"
+      FileUtils.rm_r "#{local_dir}#{file}"
       puts file
     end
 

--- a/lib/tape/installer.rb
+++ b/lib/tape/installer.rb
@@ -49,7 +49,7 @@ module TapeBoxer
     end
 
     def copy_static_app_examples
-      ["omnibox", "deploy", 'tape_vars'].each do |base_filename|
+      %w(omnibox deploy tape_vars).each do |base_filename|
         copy_example(
           "templates/static_html/#{base_filename}.example.yml",
           "#{tapefiles_dir}/#{base_filename}.yml"
@@ -58,7 +58,7 @@ module TapeBoxer
     end
 
     def copy_basic_examples
-      ["omnibox", "deploy", 'tape_vars', 'rake'].each do |base_filename|
+      %w(omnibox deploy tape_vars rake).each do |base_filename|
         copy_example(
           "templates/base/#{base_filename}.example.yml",
           "#{tapefiles_dir}/#{base_filename}.yml"

--- a/templates/base/rake.example.yml
+++ b/templates/base/rake.example.yml
@@ -8,7 +8,7 @@
   user: "{{ deployer_user.name }}"
 
   tasks:
-  - name: Runnin rake {{ task }}
+  - name: Running rake {{ task }}
     command: bash -lc "bin/rake {{ task }}"
     register: rake_output
     args:

--- a/templates/base/rake.example.yml
+++ b/templates/base/rake.example.yml
@@ -1,0 +1,18 @@
+---
+- hosts: omnibox
+
+  vars_files:
+    - "{{tape_dir}}/vars/defaults.yml"
+    - tape_vars.yml
+
+  user: "{{ deployer_user.name }}"
+
+  tasks:
+  - name: Runnin rake {{ task }}
+    command: bash -lc "bin/rake {{ task }}"
+    register: rake_output
+    args:
+      chdir: "{{ be_app_path }}"
+
+  - name: Print the rake task output
+    debug: var=rake_output.stdout_lines


### PR DESCRIPTION
## Why?

- A lot of apps have one-off rake tasks that need to be run.

## What changed?

- Added a new playbook, `rake.yml`, that can run rake tasks as the deployer.
- Added an interface for the new playbook, `tape ansible rake --task users:rank`

## Proof its working

https://github.com/Carrigan/test-tape

<img width="652" alt="screen shot 2016-06-03 at 3 02 22 pm" src="https://cloud.githubusercontent.com/assets/1082211/15789831/3b9c190c-299c-11e6-8c25-90f45d3d0569.png">
