### PR TITLE
Update ssh keys on deploy

### DIFF
--- a/templates/base/deploy.example.yml
+++ b/templates/base/deploy.example.yml
@@ -8,6 +8,7 @@
   user: "{{ deployer_user.name }}"
 
   roles:
+    - deployer_user
     - backend_checkout
     - backend_config
     - database_load


### PR DESCRIPTION
### Why?

- Currently, to give someone access to deploy, you have to run an `everything`. I don't think that should be the case

### What changed?

- Add the deployer_user role to the deploy example template