### PR TITLE
Fix a dev keys bug

### DIFF
--- a/roles/deployer_user/tasks/keys.yml
+++ b/roles/deployer_user/tasks/keys.yml
@@ -16,8 +16,8 @@
 
 
 - name: Ensure devs keys are present
-  authorized_key: key={{ lookup('file', item) }}
-                  user={{ deployer_user.name }}
-                  state=present
+  authorized_key: key="{{ lookup('file', item) }}"
+    user={{ deployer_user.name }}
+    state=present
   with_fileglob:
-    - "./dev_keys/*"
+    - "{{ playbook_dir }}/../dev_keys/*"


### PR DESCRIPTION
### Why?

- Dev keys weren't working at all. I'm actually confused how nobody noticed it before.
- When `with_fileglob` is given a relative path, it makes it relative to the roles/<rolename>/files/ directory. So that means it was really looking in something like `~/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/taperole-1.6.0/roles/deployer_user/files/./dev_keys/*` for the dev keys. Of course that's not right.

### What changed?

- Use `playbook_dir` to get the real path to the dev_keys files.