### PR TITLE
Removes a chunk of the readme, touches up other parts

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,11 @@ For a tutorial on getting started: [Taperole: the Smashing Boxes Way to Deploy Y
 
 **Install**
 
-* `$ gem install taperole` or add `gem 'taperole', '~>1.3'` to your Gemfile
+*Deprecation notice*: As of taperole 1.7, support for Ubuntu 14.x has been deprecated. If your server does not use Ubuntu 16.x, please install taperole 1.6.0 instead.
+
+* `$ gem install taperole` or add `gem 'taperole', '~>1.7'` to your Gemfile
 * `$ brew install ansible`
-* Create a [Digital Ocean Droplet](https://www.digitalocean.com/) (or any Ubuntu 14.04 system with ssh access)
+* Create a [Digital Ocean Droplet](https://www.digitalocean.com/) (or any Ubuntu 16.04 system with ssh access)
 * Run `tape installer install` in project repo
 * Update your hosts file with the IP address of your server (this can be found in your Droplet). If you go down to "Multistage", you'll see an excellent example of what your hosts file should look like.
 * Fill in missing values in `tape_vars.yml`. Should look something like this:
@@ -25,12 +27,12 @@ app_name: [app name]
 be_app_repo: [git repo]
 ```
 
-* Copy all developers public keys into a new directory (dev_keys is a good example for the name of that directory).
-* `$ tape ansible everything`
+* Copy all developers' public keys into the `taperole/dev_keys` directory.
+* Use `$ tape ansible everything` for your first deploy, then `$ tape ansible deploy` for subsequent changes.
 
 **Upgrade**
 
-**NOTE: Upgrading tape on a machine is only supported for patch versions (ie 1.3.0 to 1.3.1). For minor or major versions, it is advised that you stand up a new box, and start from stratch.
+**NOTE**: Upgrading tape on a machine is only supported for patch versions (ie 1.3.0 to 1.3.1). For minor or major versions, it is advised that you stand up a new box, and start from stratch.
 
 ```bash
 bundle update taperole
@@ -101,7 +103,6 @@ tape ansible deploy -l staging
 ## Testing
 ### With vagrant
 
-
 1. `echo 'y' | tape installer install`
 1. `vagrant up`
 2. Put the following into your [hosts inventory file](http://docs.ansible.com/intro_inventory.html):
@@ -135,25 +136,10 @@ cd tape
 ansible-galaxy install -r requirements.yml --force
 ```
 
-## 1.3 Documentation
-
-### Local System Requirements
-
-We're assuming that you're starting with the following things installed and working on your local machine:
-* unix based operating system
-* ruby (version 1.9.3 or greater)
- * Run `$ ruby --version`. You should see something like `ruby 2.2.3p173` in the output. If you see nothing or get an error, you need to install ruby. If you see something less than 1.9.3, you need to upgrade.
-* an ssh key
- * You'll need an ssh key to set up access to your server. GitHub has a [great tutorial](https://help.github.com/articles/generating-ssh-keys/) on this.
-* git and GitHub (or another remote host for your code)
- * Here's a good article on how to get going with git: https://help.github.com/articles/set-up-git/.
-* ansible
- * On a mac, we suggest using Homebrew to install ansible(`brew install ansible`). Otherwise, please refer to the ansible documentation: http://docs.ansible.com/ansible/intro_installation.html.
-
-### Rails Application Requirements
+## Rails Application Requirements
 
 Your rails application must:
-* use posgres as the database
+* use postgres as the database
 * use unicorn as the app server
 * have access to the taperole gem
 
@@ -166,95 +152,23 @@ gem 'pg'
 gem 'unicorn'
 
 # Use taperole for deployment
-gem 'taperole', '~>1.3'
+gem 'taperole', '~>1.7'
 
 ```
-Note: You can also `$ gem install taperole` and not put Taperole in your Gemfile.
 
-### Your Host Server
+Note: You can also `$ gem install taperole` and not put Taperole in your 
+Gemfile.
 
-Below are instructions for creating a digital ocean droplet to host your application.
-This is not required, as long as you have root access via ssh to an Unbuntu precise64 (14.04 x64) server.
+During your first deploy, your app will not have a `secrets.yml` file configured, and Tape will prompt you to provide one:
 
-1. Click "Create Droplet"
-2. Name your droplet. (For the purposes of this example, we'll be calling our droplet 'walkthrough'.)
-3. Select a size for your droplet. The smallest size is fine for our purposes, but if you're deploying a larger app, select whatever size is appropriate.
-4. Select a datacenter region.
-5. Choose Ubuntu 14.04.3 x64 as your image.
-6. Add your ssh key to the droplet.
-7. Create the droplet!
-
-To ensure you have ssh access as root to your server:
-`$ ssh root@0.0.0.0` should get you into the server.
-`$ pwd` in the server and you should see `/root`.
-`$ exit` to get close your session.
-
-### Provisioning/Deploying a Rails Application server with Taperole
-
-1. Confirm that `taperole`, `pg`, and `unicorn` are in your gemfile.
-2. `$ bundle`
-3. When asked `Are you going to use vagrant? (y/n):`, say `n`.
-4. Make your hosts file. Assuming you're going to have multiple environments, it should look something like this:
-```
-[production]
-0.0.0.0 be_app_env=production be_app_branch=master
-
-[omnibox:children]
-production
-```
-5. Give yourself access to the server. This needs to be the same ssh key that you used on your digital ocean droplet. So create a file called <your_name>.pub in the dev_keys folder that was generated by tape installer install. `pbcopy < ~/.ssh/id_rsa.pub` in your terminal again, then paste the result into the file you just created.
-6. Update your tape_vars.yml file.
-```
-app_name: walkthrough
-
-be_app_repo: [git repo]
-
-dev_key_files:
-  - dev_keys/your_name.pub
-```
-7. Copy all developers public keys into the `dev_keys` directory.
-8. Add this to your gitignore.
-```
-# Ignore this stuff for Taperole
-config/secrets.yml
-config/database.yml
-```
-9. If it isn't automatically, comment out front end stuff:
- * `# fe_deploy` in omnibox.yml
- * `# - frontend_deploy` in deploy.yml
-
-10. git add and commit and push to master
-11. Run `$ tape ansible everything.` This will take a long time, so grab a sandwich or something.
-12. This should chug right along until it gets to
 ```
 TASK: [backend_config | Ask for secrets.yml] **********************************
 ok: [159.203.126.223] => {
     "msg": "You've got to upload secrets.yml to /home/deployer/kevinrkiley/config to continue"
 }
 ```
-where it will hang. Don't cancel the deploy.
-13. Open a new terminal tab and generate a secret key by running `$ rake secret` from the root directory of your rails app. Don't lose this.
-14. Run `$ ssh deployer@<ip_to_server>`
-15. Once you're in the server, `$ cd walkthrough/config`. If you `$ ls`, you should see that there is no `secrets.yml` file. `$ vi secrets.yml` to create it.
-16. When you're done secrets.yml should look something like:
-```
-production:
-  secret_key_base: thisisthesecretkeyyougeneratedinstep9
-```
-17. Your deployment should automatically continue.
 
-
-### Deploying your latest changes
-
-To deploy your latest changes to your tape-provisioned server:
-
-```
-tape ansible deploy
-```
-
-This will git pull the latest changes from the tracking branch you specified and restart all services via monit.
-
-This command runs all Ansible roles specified in the deploy.yml playbook.
+To continue the deploy, SSH into the server as the `deployer` user and create your `config/secrets.yml` file in the app directory. The deploy will automatically continue when the file is saved.
 
 ### Rake tasks
 


### PR DESCRIPTION
### Why?

- The README had a lot of old information (rot) and cruft.

### What?

- Adds a notice about Tape 1.7 no longer supporting Ubuntu 14
- Updates the readme to reference Ubuntu 16 throughout
- Removes local system requirements
- Removes all of the tutorial content, since:
  - We link to a tutorial article
  - It's not our responsibility to document how Digital Ocean works