### PR TITLE
Fix an issue with monitrc

### DIFF
--- a/file.md
+++ b/file.md
@@ -1,0 +1,42 @@
+# Setting Up Lets Encrypt
+* ssh into your server as root.
+* run: `git clone https://github.com/letsencrypt/letsencrypt /opt/letsencrypt`
+* stop nginx by running: `monit stop all`
+* cd into `/opt/letsencrypt`
+* run: `./letsencrypt-auto certonly --standalone` (note: that's dash-dash-standalone)
+* You should see a blue screen/form.  Fill in the requested information.  (note: you can enter the naked domain and use www, i.e. example.com and www.example.com; follow the instructions for multiple domains)
+* If everything was successful, you will see a success message.  If not, a likely culprit is that nginx is still running, or you typed the wrong domain name (or haven't set the domain name up yet)
+* Update your nginx config to point to he new SSL certs.  The config file can be found at `/etc/nginx/sites-enabled/your-app-name`.  
+
+**Example**
+
+```
+ssl on;
+  ssl_certificate /etc/letsencrypt/live/api.raq-staging.sbox.es/fullchain.pem;
+  ssl_certificate_key /etc/letsencrypt/live/api.raq-staging.sbox.es/privkey.pem;
+```
+
+* Restart monit:  `monit restart all`.
+
+*Note*:  
+Let's Encrypt certificates are good for three months.  We'll need to set up a cron job on the sever to automatically renew them for us.
+
+* Run: `crontab -e`, which will open a cron tab.
+* Choose your favorite unix editor, and then insert:
+
+```
+30 2 * * 1 monit stop all
+31 2 * * 1 /opt/letsencrypt/letsencrypt-auto renew >> /var/log/le-renew.log
+32 2 * * 1 monit start all
+```
+
+* Save and exit.
+* You need to use the `nginx-letsencrypt` Ansible role. Change the line `- nginx` in your omnibox.yml file to `- nginx-letsencrypt`
+* Set the `domain` variable in your tape_vars.yml file (should be same as domain you set at the blue screen earlier).
+* Run `tape ansible everything`
+
+That's it!  Refresh your browser and make sure you have the green lock.  If not, you probably haven't set up nginx correctly.
+
+More information:
+Digital ocean / Let's Encrypt [video tutorial](https://www.youtube.com/watch?v=m9aa7xqX67c)
+Digital ocean [article](https://www.digitalocean.com/community/tutorials/how-to-secure-nginx-with-let-s-encrypt-on-ubuntu-14-04) regarding setting up Let's Encrypt

--- a/roles/monit_install/templates/monitrc.j2
+++ b/roles/monit_install/templates/monitrc.j2
@@ -287,4 +287,4 @@
 ## directories.
 #
   include /etc/monit/conf.d/*
-  include /etc/monit/conf-enabled/*
+# include /etc/monit/conf-enabled/*

--- a/roles/nginx-letsencrypt/handlers/main.yml
+++ b/roles/nginx-letsencrypt/handlers/main.yml
@@ -1,0 +1,2 @@
+- name: restart nginx
+  command: bash -lc "sudo monit restart nginx"

--- a/roles/nginx-letsencrypt/tasks/main.yml
+++ b/roles/nginx-letsencrypt/tasks/main.yml
@@ -1,0 +1,42 @@
+- name: Enable nginx PPA
+  apt_repository: repo=ppa:nginx/stable
+  tags: [nginx]
+
+- name: Install nginx
+  apt: name=nginx state=present
+  tags: [nginx]
+
+- name: Ditch default nginx site enabled
+  file: path=/etc/nginx/sites-enabled/default state=absent
+  tags: [nginx]
+
+- name: Create /etc/nginx/ssl
+  file: path=/etc/nginx/ssl state=directory
+  tags: [nginx]
+
+- name: Create Diffie Hellman Ephemeral Parameters (this will take some time)
+  command: bash -lc "openssl dhparam -out dhparam.pem 2048"
+  args:
+    chdir: /etc/nginx/ssl
+  tags: [nginx]
+
+- name: Configure App nginx
+  template: src=nginx_unicorn.j2 dest=/etc/nginx/sites-enabled/{{ app_name }}
+  tags: [nginx]
+
+- name: Install monit nginx config
+  file: src=/etc/monit/conf-available/nginx dest=/etc/monit/conf-enabled/nginx owner=root group=root state=link
+  register: nginx_monit_config
+
+- name: Reload Monit
+  command: bash -lc "monit reload && sleep 2"
+  when: nginx_monit_config.changed
+
+- name: Stop nginx
+  service: name=nginx state=stopped
+  tags: [restart_nginx]
+
+- name: Start nginx
+  remote_user: "{{ deployer_user.name }}"
+  command: bash -lc "sudo monit start nginx"
+  tags: [restart_nginx]

--- a/roles/nginx-letsencrypt/templates/nginx_unicorn.j2
+++ b/roles/nginx-letsencrypt/templates/nginx_unicorn.j2
@@ -1,0 +1,80 @@
+{% if be_app_repo is defined %}
+upstream unicorn {
+  server unix:{{unicorn_sockfile}} fail_timeout=0;
+}
+{% endif %}
+server {
+  listen 80;
+  return 301 https://$host$request_uri;
+}
+
+
+server {
+  listen 443 default deferred;
+
+  # server_name example.com;
+
+  ssl on;
+  ssl_certificate /etc/letsencrypt/live/{{ domain }}/fullchain.pem;
+  ssl_certificate_key /etc/letsencrypt/live/{{ domain }}/privkey.pem;
+  ssl_dhparam /etc/nginx/ssl/dhparam.pem;
+
+  ssl_prefer_server_ciphers on;
+  ssl_session_cache shared:SSL:10m;
+  ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+
+  ssl_stapling on;
+  ssl_stapling_verify on;
+  resolver 8.8.8.8 8.8.4.4 valid=300s;
+  resolver_timeout 5s;
+
+  ssl_ciphers 'ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:AES:CAMELLIA:DES-CBC3-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA';
+
+  add_header Strict-Transport-Security "max-age=63072000; includeSubdomains; preload";
+  add_header X-Frame-Options "DENY";
+  add_header Public-Key-Pins 'pin-sha256="klO23nT2ehFDXCfx3eHTDRESMz3asj1muO+4aIdjiuY="; pin-sha256="633lt352PKRXbOwf4xSEa1M517scpD3l5f79xMD9r9Q="; max-age=2592000; includeSubDomains';
+
+{% if fe_app_repo is defined %}
+  root {{ fe_app_path }}/dist;
+{% else %}
+  root {{ be_app_path }}/public;
+{% endif %}
+
+  if (-f $document_root/system/maintenance.html) {
+    return 503;
+  }
+  error_page 503 @maintenance;
+  location @maintenance {
+    rewrite  ^(.*)$  /system/maintenance.html last;
+    break;
+  }
+
+  location ^~ /assets/ {
+    gzip_static on;
+    expires max;
+    add_header Cache-Control public;
+  }
+
+{% if be_app_repo is defined %}
+  try_files $uri/index.html $uri @unicorn;
+  location @unicorn {
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header Host $http_host;
+    proxy_redirect off;
+    proxy_pass http://unicorn;
+  }
+{% endif %}
+
+  error_page 500 502 503 504 /500.html;
+  client_max_body_size 4G;
+  keepalive_timeout 10;
+
+  if (-f $document_root/system/maintenance.html) {
+    return 503;
+  }
+  error_page 503 @maintenance;
+  location @maintenance {
+    rewrite  ^(.*)$  /system/maintenance.html last;
+    break;
+  }
+}

--- a/roles/nginx/templates/nginx_monit.j2
+++ b/roles/nginx/templates/nginx_monit.j2
@@ -1,3 +1,0 @@
-check process nginx with pidfile /var/run/nginx.pid
-  start program = "/etc/init.d/nginx start"
-  stop program  = "/etc/init.d/nginx stop"

--- a/templates/base/hosts.example
+++ b/templates/base/hosts.example
@@ -1,6 +1,6 @@
 # Base Example
 [omnibox]
-0.0.0.0 be_app_env=SOME_ENV be_app_branch=SOME_BRANCH 
+0.0.0.0 be_app_env=SOME_ENV be_app_branch=SOME_BRANCH
 
 # Vagrant Example
 # [omnibox]

--- a/templates/base/tape_vars.example.yml
+++ b/templates/base/tape_vars.example.yml
@@ -1,5 +1,8 @@
 app_name:
 
+# Set this in your hosts file if you have multiple environments
+domain:
+
 # Rails App Configs
 be_app_repo:
 

--- a/templates/static_html/tape_vars.example.yml
+++ b/templates/static_html/tape_vars.example.yml
@@ -1,5 +1,8 @@
 app_name:
 
+# Set this in your hosts file if you have multiple environments
+domain:
+
 # App Configs
 fe_app_repo:
 fe_app_branch: master


### PR DESCRIPTION
After setting up a brand new box with tape, and trying to do `monit restart all`, I was running into this:

```
/etc/monitrc:290: Include failed -- Success '/etc/monit/conf-enabled/*'
```

To fix it, I simply commented out line 290 in `/etc/monitrc` (`include /etc/monit/conf-enabled/*`). 