### PR TITLE
Allow alternative git workflow

### DIFF
--- a/lib/taperole/commands/ansible.rb
+++ b/lib/taperole/commands/ansible.rb
@@ -32,7 +32,7 @@ module Taperole
                    aliases: :r,
                    type: :string,
                    desc: 'Name of the role to operate on'
-      class_option :extras
+      class_option :extras,
                    aliases: :e,
                    type: :string,
                    desc: 'Extra variables to be passed into ansible'

--- a/lib/taperole/commands/ansible.rb
+++ b/lib/taperole/commands/ansible.rb
@@ -32,6 +32,10 @@ module Taperole
                    aliases: :r,
                    type: :string,
                    desc: 'Name of the role to operate on'
+      class_option :extras
+                   aliases: :e,
+                   type: :string,
+                   desc: 'Extra variables to be passed into ansible'
 
       class_option :'ask-vault-pass', type: :boolean, desc: 'Ask for Ansible vault password'
 

--- a/lib/taperole/core/ansible_runner.rb
+++ b/lib/taperole/core/ansible_runner.rb
@@ -47,7 +47,7 @@ module Taperole
       enforce_roles_path!
       cmd = "ANSIBLE_CONFIG=#{local_dir}/.tape/ansible.cfg ansible-playbook -i"
       cmd += " #{inventory_file(options)} #{playbook} #{args} #{hosts_flag(options)}"
-      cmd += " -e tape_dir=#{tape_dir}"
+      cmd += " -e \"#{extra_vars(options)}\""
       cmd += ' --ask-vault-pass' if options['ask-vault-pass']
       cmd += ' -vvvv' if options[:verbose]
       cmd += " -t #{options[:tags]}" if options[:tags]
@@ -71,6 +71,17 @@ module Taperole
         f.puts "retry_files_enabled = False"
         f.puts '[ssh_connection]'
         f.puts 'ssh_args=-o ForwardAgent=yes'
+      end
+    end
+
+    def extra_vars(options)
+      base_vars = "tape_dir=#{tape_dir}"
+      extra_vars = options[:extras]
+
+      if extra_vars
+        base_vars + " " + extra_vars
+      else
+        base_vars
       end
     end
 

--- a/roles/database_load/defaults/main.yml
+++ b/roles/database_load/defaults/main.yml
@@ -1,3 +1,2 @@
 rake:
-  force_seed: false
   force_migrate: false

--- a/roles/database_load/tasks/db_reset.yml
+++ b/roles/database_load/tasks/db_reset.yml
@@ -1,14 +1,17 @@
-- name: stop everything
-  command: bash -lc "monit stop all"
+- name: Confirm Reset
+  pause: prompt='About to destroy and reseed the database. Press any key to continue or Ctrl+c and then "a" to abort'
+
+- name: Stop all Services
+  command: bash -lc "sudo monit stop all"
 
 - name: Reset DB
   command: chdir={{ be_app_path }}
-           bash -lc "bundle exec rake db:drop db:create RAILS_ENV={{be_app_env}}"
+           bash -lc "bundle exec rake db:drop db:setup RAILS_ENV={{be_app_env}}"
   register: db_reset
 
 - name: DB Reset Failed
   fail: msg="{{db_reset.stderr}}"
   when: db_reset.stderr
 
-- name: start unicorns
-  command: bash -lc "monit start all"
+- name: Restart Services
+  command: bash -lc "sudomonit start all"

--- a/roles/database_load/tasks/db_reset.yml
+++ b/roles/database_load/tasks/db_reset.yml
@@ -14,4 +14,4 @@
   when: db_reset.stderr
 
 - name: Restart Services
-  command: bash -lc "sudomonit start all"
+  command: bash -lc "sudo monit start all"


### PR DESCRIPTION
## Why?

The current workflow that Tape requires is to map a server 1 to 1 with a branch. For instance, the `development` branch maps to the staging server, and `master` to production. The problem, especially in longer running projects, is that when large features are introduced into development, they can often block smaller features or bug fixes until the large feature has been fully QA accepted. This often leads to larger, riskier deploys to production.

There is an alternate way of branching that I was introduced to at the end of our Weaveup engagement that solves this problem. Instead of the flow `Open PR -> Code Review -> Merge -> QA from development`, the flow changes to `Open PR -> Code Review -> QA directly from feature or bugfix branch -> Merge`. This has the following advantages:
- Your master branch is always QA approved. You may deploy it at any time to any production environment.
- QA can trace where a bug came from, and not accept a branch until it is fixed. This means that when bugs are found in a branch, instead of opening a new bug card in Jira, our QA department can comment in the PR directly, reducing communication overhead.
- There is no need to go through the ladder of "Merge dev into staging, now push, now merge staging into preprod, now push..." when a new deploy is ready. Just mash that deploy button.

## What Changed?

I made a few small modifications that will allow us to try this new workflow without fully buying in:

- Update the currently-unused `db_reset.yml` file, which allows us to blow away the database and reseed it. When working in the above workflow, this can be handy since a server will not always linearly receive migrations.
- Add a manual prompt warning in the `db_reset.yml` file about the fact that it will drop and recreate the database.

<img width="810" alt="screen shot 2016-12-29 at 3 54 56 pm" src="https://cloud.githubusercontent.com/assets/1082211/21555037/7bf12138-cde2-11e6-84b8-9da12e7ba2c1.png">

- Add the `-e` flag to the Ansible runner. This will allow extra variables to be manually defined.

---

To use the flow defined in the `Why?`, the following syntax can be used:

```
bundle exec tape ansible deploy -e "be_app_branch=other-branch force_db_reset=true" -l QA
```

This will allow us to trial this flow, and if it goes well, to modify our ansible scripts so that the syntax could be something cleaner like:

```
bundle exec tape ansible deploy --qa branch
```
