### PR TITLE
Move deployment of dev_keys out of deployer_user role

### DIFF
--- a/roles/deployer_user/tasks/keys.yml
+++ b/roles/deployer_user/tasks/keys.yml
@@ -14,10 +14,3 @@
     owner={{ deployer_user.name }}
     group=users
     mode=600
-
-- name: Ensure devs keys are present
-  authorized_key: key="{{ lookup('file', item) }}"
-    user={{ deployer_user.name }}
-    state=present
-  with_fileglob:
-    - "{{ playbook_dir }}/../dev_keys/*"

--- a/roles/dev_keys/tasks/main.yml
+++ b/roles/dev_keys/tasks/main.yml
@@ -1,0 +1,6 @@
+- name: Ensure developer keys are present in deployer's ssh keys
+  authorized_key: key="{{ lookup('file', item) }}"
+    user={{ deployer_user.name }}
+    state=present
+  with_fileglob:
+    - "{{ playbook_dir }}/../dev_keys/*"

--- a/templates/base/deploy.example.yml
+++ b/templates/base/deploy.example.yml
@@ -8,7 +8,7 @@
   user: "{{ deployer_user.name }}"
 
   roles:
-    - deployer_user
+    - dev_keys
     - backend_checkout
     - backend_config
     - database_load

--- a/templates/base/omnibox.example.yml
+++ b/templates/base/omnibox.example.yml
@@ -25,6 +25,7 @@
     - general
     - ufw
     - deployer_user
+    - dev_keys
     - monit_install
     - postgres
     - nginx


### PR DESCRIPTION
### Why?

I recently added the `deployer_user` role to the `deploy.yml` playbook, so that dev_keys would be deployed on each deployment. That started causing this error:

```
TASK [deployer_user : Copy of root ssh keys] ***********************************
fatal: [138.197.27.240]: FAILED! => {"changed": true, "cmd": ["cp", "/root/.ssh/authorized_keys", "/home/deployer/.ssh/authorized_keys"], "delta": "0:00:00.003396", "end": "2017-01-04 20:49:46.822555", "failed": true, "rc": 1, "start": "2017-01-04 20:49:46.819159", "stderr": "cp: cannot stat '/root/.ssh/authorized_keys': Permission denied", "stdout": "", "stdout_lines": [], "warnings": []}
```

That's because it was trying to more steps than just copying dev_keys. It was also trying to copy root's `authorized_keys`, which deployer didn't have permissions to do.

### What changed?

- Split the `dev_keys` part of the `deployer_user` role into it's own role, and only include that `deploy.yml`
- Add the new `dev_keys` role to `omnibox.yml` as well, so `everything`'s behavior stays the same

### Note: This change will fix the issue for future projects created with tape, but existing projects will need to update their `deploy.yml` and `omnibox.yml` files.