### PR TITLE
Set X-Forwarded-Proto Header in nginx

### DIFF
--- a/roles/nginx/templates/nginx_puma.j2
+++ b/roles/nginx/templates/nginx_puma.j2
@@ -81,6 +81,7 @@ server {
   try_files $uri/index.html $uri @puma;
   location @puma {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
     proxy_set_header Host $http_host;
     proxy_redirect off;
     proxy_pass http://puma;


### PR DESCRIPTION
### Why?
Using `force_ssl` in Rails causes a redirect loop on the server without this header set

### What Changed?
Set the `X-Forwarded-Proto` header