### PR TITLE
Restart nginx when certbot renews certificate

### DIFF
--- a/roles/letsencrypt/tasks/main.yml
+++ b/roles/letsencrypt/tasks/main.yml
@@ -14,6 +14,6 @@
     weekday: 1
     hour: 2
     minute: 30
-    job: /usr/bin/letsencrypt renew --rsa-key-size 4096 >> /var/log/le-renew.log
+    job: /usr/bin/letsencrypt renew --rsa-key-size 4096 --renew-hook "/usr/bin/monit restart nginx" >> /var/log/le-renew.log
     user: root
   when: letsencrypt.enabled == true

--- a/roles/letsencrypt/tasks/main.yml
+++ b/roles/letsencrypt/tasks/main.yml
@@ -1,9 +1,11 @@
 - name: Install letsencrypt
-  apt: name=letsencrypt state=present
+  command: bash -lc "git clone https://github.com/letsencrypt/letsencrypt /opt/letsencrypt"
+  args:
+    creates: /opt/letsencrypt
   when: letsencrypt.enabled == true
 
 - name: Get letsencrypt cert
-  command: bash -lc "letsencrypt certonly --standalone --rsa-key-size 4096 --force-renew --agree-tos --email {{ letsencrypt.email }} --text --non-interactive -d {{ letsencrypt.hostname }}"
+  command: bash -lc "/opt/letsencrypt/letsencrypt-auto certonly --standalone --rsa-key-size 4096 --force-renew --agree-tos --email {{ letsencrypt.email }} --text --non-interactive -d {{ letsencrypt.hostname }}"
   args:
     creates: "/etc/letsencrypt/live/{{ letsencrypt.hostname }}/privkey.pem"
   when: letsencrypt.enabled == true
@@ -14,6 +16,6 @@
     weekday: 1
     hour: 2
     minute: 30
-    job: /usr/bin/letsencrypt renew --rsa-key-size 4096 --renew-hook "/usr/bin/monit restart nginx" >> /var/log/le-renew.log
+    job: /opt/letsencrypt/letsencrypt-auto renew --rsa-key-size 4096 --renew-hook "/usr/bin/monit restart nginx" >> /var/log/le-renew.log
     user: root
   when: letsencrypt.enabled == true


### PR DESCRIPTION
## What Changed
* Use the letsencrypt renew-hook to restart nginx on renew

## Why
* Nginx must be restarted when a certificate is renewed