### PR TITLE
Stop nginx on certbot renew

### DIFF
--- a/roles/letsencrypt/tasks/main.yml
+++ b/roles/letsencrypt/tasks/main.yml
@@ -16,6 +16,6 @@
     weekday: 1
     hour: 2
     minute: 30
-    job: /opt/letsencrypt/letsencrypt-auto renew --rsa-key-size 4096 --renew-hook "/usr/bin/monit restart nginx" >> /var/log/le-renew.log
+    job: /opt/letsencrypt/letsencrypt-auto renew --rsa-key-size 4096 --pre-hook "/usr/bin/monit stop nginx" --pre-hook "/usr/bin/monit start nginx" >> /var/log/le-renew.log
     user: root
   when: letsencrypt.enabled == true

--- a/roles/letsencrypt/tasks/main.yml
+++ b/roles/letsencrypt/tasks/main.yml
@@ -16,6 +16,6 @@
     weekday: 1
     hour: 2
     minute: 30
-    job: /opt/letsencrypt/letsencrypt-auto renew --rsa-key-size 4096 --pre-hook "/usr/bin/monit stop nginx" --pre-hook "/usr/bin/monit start nginx" >> /var/log/le-renew.log
+    job: /opt/letsencrypt/letsencrypt-auto renew --rsa-key-size 4096 --pre-hook "/usr/bin/monit stop nginx" --post-hook "/usr/bin/monit start nginx" >> /var/log/le-renew.log
     user: root
   when: letsencrypt.enabled == true


### PR DESCRIPTION
## What Changed
* Use --pre-hook to stop nginx before cert renew
* Suggested by [this Let's Encrypt thread](https://community.letsencrypt.org/t/nginx-auto-renewal/30894)

## Why
* Renewal will fail if nginx is running because LE needs to have access to port 443 to not be taken by any process (NGINX)