### PR TITLE
Adds init info to fix apt-get upgrade and other related stuff

### DIFF
--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -18,7 +18,7 @@
   when: letsencrypt.enabled == false
 
 - name: Create Diffie Hellman Ephemeral Parameters (this will take some time)
-  command: bash -lc "openssl dhparam -out dhparam.pem 2048"
+  command: bash -lc "openssl dhparam -out /etc/nginx/ssl/dhparam.pem 2048"
   args:
     creates: /etc/nginx/ssl/dhparam.pem
 

--- a/roles/puma_install/templates/puma_init.j2
+++ b/roles/puma_install/templates/puma_init.j2
@@ -1,5 +1,18 @@
 #!/usr/bin/env bash
 
+### BEGIN INIT INFO
+# Provides:          puma
+# Required-Start:
+# Required-Stop:
+# Should-Start:
+# Should-Stop:
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: puma rails server
+# Description:       puma serves rails fast
+### END INIT INFO
+
+
 # This monit wrapper script will be called by monit as root
 # Edit these variables to your liking
 


### PR DESCRIPTION
# Why?
- Ran into this issue with #137 

# What changed?
- This fixes the puma init script so that it doesn't cause `apt-get upgrade` to fail (which in turn causes a whole host of other things to fail)