### PR TITLE
Update the expected redis-server pidfile

### DIFF
--- a/roles/redis/templates/redis.j2
+++ b/roles/redis/templates/redis.j2
@@ -1,5 +1,5 @@
 check process redis-server
-    with pidfile "/var/run/redis/redis.pid"
+    with pidfile "/var/run/redis/redis-server.pid"
     start program = "/etc/init.d/redis-server start"
     stop program = "/etc/init.d/redis-server stop"
     if 2 restarts within 3 cycles then timeout


### PR DESCRIPTION
## Why?
Monit failed to find the redis-server pidfile because it was not at the expected location. After provisioning with the `redis` role, the ` /etc/init.d/redis-server` specifies `PIDFILE=$RUNDIR/redis-server.pid`.

## What Changed?
Update the expected redis-server pid location to `/var/run/redis/redis-server.pid`