### PR TITLE
Bump up the default swapfile size because some webpack plugins are heavy

### DIFF
--- a/roles/general/tasks/swapfile.yml
+++ b/roles/general/tasks/swapfile.yml
@@ -17,7 +17,7 @@
   mount: name=none src={{ swap_file.path }} fstype=swap opts=sw passno=0 dump=0 state=present
 
 - name: Check swapon swapfile
-  raw: swapon | grep "{{ swap_file.path }}"
+  shell: swapon | grep "{{ swap_file.path }}"
   ignore_errors: True
   register: swap_file_is_on
 

--- a/roles/general/tasks/swapfile.yml
+++ b/roles/general/tasks/swapfile.yml
@@ -16,6 +16,10 @@
 - name: Put the swap entry into fstab
   mount: name=none src={{ swap_file.path }} fstype=swap opts=sw passno=0 dump=0 state=present
 
+- name: Check swapon swapfile
+  command: swapon | grep "{{ swap_file.path }}"
+  register: swap_file_is_on
+
 - name: Swapon swapfile
   command: swapon {{ swap_file.path }}
-  when: ansible_swaptotal_mb < 1
+  when: swap_file_is_on.stdout.find('{{ swap_file.path }}') != 1

--- a/roles/general/tasks/swapfile.yml
+++ b/roles/general/tasks/swapfile.yml
@@ -17,9 +17,9 @@
   mount: name=none src={{ swap_file.path }} fstype=swap opts=sw passno=0 dump=0 state=present
 
 - name: Check swapon swapfile
-  command: swapon | grep "{{ swap_file.path }}"
-  register: swap_file_is_on
+  raw: swapon | grep "{{ swap_file.path }}"
+  register: swapfile_is_on
 
 - name: Swapon swapfile
   command: swapon {{ swap_file.path }}
-  when: swap_file_is_on.stdout.find('{{ swap_file.path }}') == -1
+  when: swapfile_is_on.stdout == ""

--- a/roles/general/tasks/swapfile.yml
+++ b/roles/general/tasks/swapfile.yml
@@ -18,8 +18,10 @@
 
 - name: Check swapon swapfile
   raw: swapon | grep "{{ swap_file.path }}"
-  register: swapfile_is_on
+  ignore_errors: True
+  register: swap_file_is_on
 
 - name: Swapon swapfile
   command: swapon {{ swap_file.path }}
-  when: swapfile_is_on.stdout == ""
+  when: swap_file_is_on.stdout == ""
+

--- a/roles/general/tasks/swapfile.yml
+++ b/roles/general/tasks/swapfile.yml
@@ -22,4 +22,4 @@
 
 - name: Swapon swapfile
   command: swapon {{ swap_file.path }}
-  when: swap_file_is_on.stdout.find('{{ swap_file.path }}') != 1
+  when: swap_file_is_on.stdout.find('{{ swap_file.path }}') == -1

--- a/vars/defaults.yml
+++ b/vars/defaults.yml
@@ -22,7 +22,7 @@ puma_sockfile: "{{ be_app_path }}/tmp/puma_{{ app_name }}.sock"
 
 swap_file:
   path: /swp
-  size_kb: "{{ 1024 * 1024 }}"
+  size_kb: "{{ 2 * 1024 * 1024 }}"
 
 # echo 'password' | md5
 database_password: 286755fad04869ca523320acce0dc6a4

--- a/vars/defaults.yml
+++ b/vars/defaults.yml
@@ -22,7 +22,7 @@ puma_sockfile: "{{ be_app_path }}/tmp/puma_{{ app_name }}.sock"
 
 swap_file:
   path: /swp
-  size_kb: "{{ 2 * 1024 * 1024 }}"
+  size_kb: "{{ 3 * 1024 * 1024 }}"
 
 # echo 'password' | md5
 database_password: 286755fad04869ca523320acce0dc6a4


### PR DESCRIPTION
# Why?
- Ran in to weird non-specific issues during webpack compilation involving large images

# What changed?
- Even though it's possible to bump up the size of the swap file on a per-project basis, there's not much of a reason to have this be a problem that we run in to unexpectedly, so I bumped up the swapfile to 3bg.
- Also changed the swap file role to perform a `swapon` of the swap file if it is not already on -- this helps when adding another swap file on a server that is already provisioned. The previous method would not let an additional swapfile be created if one already existed.