### PR TITLE
Update deprecated 'always_run: yes' to 'check_mode: no'

### DIFF
--- a/roles/ruby/tasks/main.yml
+++ b/roles/ruby/tasks/main.yml
@@ -68,7 +68,7 @@
   register: ruby_installed
   changed_when: false
   ignore_errors: yes
-  always_run: yes
+  check_mode: no
   when: rbenv.env == "system"
 
 - name: install ruby {{ rbenv.ruby_version }} for system
@@ -82,7 +82,7 @@
   register: ruby_selected
   changed_when: false
   ignore_errors: yes
-  always_run: yes
+  check_mode: no
   when: rbenv.env == "system"
 
 - name: set ruby {{ rbenv.ruby_version }} for system


### PR DESCRIPTION
## Why?
The `ruby` role prints out a warning because `always_run` is deprecated. It's replaced by `check_mode: no` per the ansible docs:
"Prior to version 2.2 only the the equivalent of check_mode: no existed. The notation for that was always_run: yes."
http://docs.ansible.com/ansible/latest/playbooks_checkmode.html

## What Changed?
Replace `always_run: yes` with `check_mode: no`