### PR TITLE
Fix a typo

### DIFF
--- a/roles/whenever/tasks/main.yml
+++ b/roles/whenever/tasks/main.yml
@@ -1,4 +1,4 @@
 - name: Wheneverize
   remote_user: "{{ deployer_user.name }}"
   command: chdir={{ be_app_path }}
-           bash -lc bundle exec whenever --update-crontab --set environment={{be_app_env}}"
+           bash -lc bundle exec whenever --update-crontab --set environment={{be_app_env}}


### PR DESCRIPTION
### Why?
- With the current config, whenever fails with this error:
```
ERROR! failed at splitting arguments, either an unbalanced jinja2 block or quotes: chdir={{ be_app_path }} bash -lc bundle exec whenever --update-crontab --set environment={{be_app_env}}"

The error appears to have been in '/Users/dkniffin/Repositories/orangecaregroup-portal/taperole/roles/whenever/tasks/main.yml': line 1, column 3, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:


- name: Wheneverize
  ^ here

exception type: <class 'ansible.errors.AnsibleParserError'>
exception: failed at splitting arguments, either an unbalanced jinja2 block or quotes: chdir={{ be_app_path }} bash -lc bundle exec whenever --update-crontab --set environment={{be_app_env}}"
```

### What changed?
- Removed a `"`