### PR TITLE
Adds yarn role

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    taperole (2.0.0)
+    taperole (2.0.7)
       colorize (~> 0.8.1)
       slack-notifier (~> 1.5)
       thor (~> 0.19.1)
@@ -38,4 +38,4 @@ DEPENDENCIES
   taperole!
 
 BUNDLED WITH
-   1.12.5
+   1.16.1

--- a/roles/yarn_install/tasks/main.yml
+++ b/roles/yarn_install/tasks/main.yml
@@ -1,0 +1,16 @@
+---
+- name: Import the yarn GPG key into apt
+  apt_key:
+    url: https://dl.yarnpkg.com/debian/pubkey.gpg
+    state: present
+
+- name: Add yarn package deb repository
+  apt_repository:
+    repo: 'deb https://dl.yarnpkg.com/debian/ stable main'
+    state: present
+
+- name: Install yarn
+  apt:
+    pkg: yarn
+    state: installed
+    update_cache: yes

--- a/templates/base/provision.example.yml
+++ b/templates/base/provision.example.yml
@@ -32,6 +32,7 @@
     - nginx
     - backend_install_essentials
     - frontend_install_essentials
+    - yarn_install
     - backend_checkout
     - puma_install
     - backend_config

--- a/templates/base/tape_vars.example.yml
+++ b/templates/base/tape_vars.example.yml
@@ -12,7 +12,7 @@ be_app_repo:
 # Uncomment if you want to deploy a JS/HTML App
 # fe_app_repo:
 # fe_app_branch: master
-# fe_build_command: npm run build
+# fe_build_command: yarn run build:production
 
 slack_webhook_url:
 


### PR DESCRIPTION
### Why?

We're using yarn by default now, so we should add a role for it.

### What Changed?

* Adds `yarn_install` role
* Ran bundle, which updated `tape`

### Note

Yarn suggests installing using this method ([docs](https://yarnpkg.com/en/docs/install#linux-tab)):

> Note: Installation of Yarn via npm is generally not recommended. When installing Yarn with Node-based package managers, the package is not signed, and the only integrity check performed is a basic SHA1 hash, which is a security risk when installing system-wide apps.

> For these reasons, it is highly recommended that you install Yarn through the installation method best suited to your operating system.

[Source](https://yarnpkg.com/en/docs/install#alternatives-tab)
