### PR TITLE
Move install_yarn to a dependency of frontend_install_essentials

### DIFF
--- a/roles/frontend_install_essentials/meta/main.yml
+++ b/roles/frontend_install_essentials/meta/main.yml
@@ -1,3 +1,4 @@
 ---
 dependencies:
   - role: node
+  - role: install_yarn

--- a/templates/base/provision.example.yml
+++ b/templates/base/provision.example.yml
@@ -32,7 +32,6 @@
     - nginx
     - backend_install_essentials
     - frontend_install_essentials
-    - install_yarn
     - backend_checkout
     - puma_install
     - backend_config


### PR DESCRIPTION
### Why?

- If `install_yarn` is listed as a separate item in `provision.yml`, it won't be picked up by existing projects, unless they manually add it their `provision.yml`

### What changed?

- Move `install_yarn` to a dependency of `frontend_install_essentials`