### PR TITLE
Configure unattended-upgrades to remove unused dependencies

### DIFF
--- a/roles/general/meta/main.yml
+++ b/roles/general/meta/main.yml
@@ -1,4 +1,5 @@
 ---
 dependencies:
   - role: jnv.unattended-upgrades
+    unattended_remove_unused_dependencies: true
   - role: tersmitten.htop


### PR DESCRIPTION
## Why?
unattended-upgrades sit around on disk. Over time, they take up a huge amount of disk space. At a certain point, they fill so much space that all apt commands fail & it becomes a pain to recover the server & clear out the old kernels.

## What Changed?
Set the `unattended_remove_unused_dependencies` option.
reference: https://github.com/jnv/ansible-role-unattended-upgrades#role-variables