### PR TITLE
Logrotate

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -15,3 +15,5 @@
 - src: https://github.com/Oefenweb/ansible-sysfs
   name: ansible-sysfs
   version: v1.0.2
+
+- src: nickhammond.logrotate

--- a/templates/base/tape_vars.example.yml
+++ b/templates/base/tape_vars.example.yml
@@ -16,6 +16,17 @@ be_app_repo:
 
 slack_webhook_url:
 
+logrotate_scripts:
+  - name: rails
+    path: "{{be_app_path}}/log/*.log"
+    options:
+      - daily
+      - rotate 30
+      - missingok
+      - compress
+      - delaycompress
+      - copytruncate
+
 ## Configure Postgresql Backups
 ## Uncomment the following to enabled backups
 #

--- a/test/rails/tape_vars.yml
+++ b/test/rails/tape_vars.yml
@@ -15,3 +15,14 @@ be_app_repo: https://github.com/BrandonMathis/vanilla-rails-app.git
 # fe_build_command: yarn run build:production
 
 slack_webhook_url:
+
+logrotate_scripts:
+  - name: rails
+    path: "{{be_app_path}}/log/*.log"
+    options:
+      - daily
+      - rotate 30
+      - missingok
+      - compress
+      - delaycompress
+      - copytruncate

--- a/vendor/nickhammond.logrotate/.gitignore
+++ b/vendor/nickhammond.logrotate/.gitignore
@@ -1,0 +1,2 @@
+tests/.vagrant
+test.retry

--- a/vendor/nickhammond.logrotate/.travis.yml
+++ b/vendor/nickhammond.logrotate/.travis.yml
@@ -1,0 +1,14 @@
+---
+language: python
+python: "2.7"
+before_install:
+  - sudo apt-get update -qq
+  - sudo apt-get install -qq python-apt python-pycurl
+install:
+  - pip install ansible
+script:
+  - "printf '[defaults]\nroles_path = ../' > ansible.cfg"
+  - ansible-playbook -i tests/inventory --syntax-check tests/test.yml
+  - ansible-playbook -i tests/inventory --connection=local --become -vvvv tests/test.yml
+notifications:
+  email: false

--- a/vendor/nickhammond.logrotate/LICENSE
+++ b/vendor/nickhammond.logrotate/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2016-14, Nick Hammond
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of ansiblebit nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/nickhammond.logrotate/README.md
+++ b/vendor/nickhammond.logrotate/README.md
@@ -1,0 +1,109 @@
+# logrotate
+
+[![Build Status](https://travis-ci.org/nickhammond/ansible-logrotate.svg?branch=master)](https://travis-ci.org/nickhammond/ansible-logrotate)
+
+Installs logrotate and provides an easy way to setup additional logrotate scripts by
+specifying a list of directives.
+
+## Requirements
+
+None
+
+## Role Variables
+
+**logrotate_scripts**: A list of logrotate scripts and the directives to use for the rotation.
+
+* name - The name of the script that goes into /etc/logrotate.d/
+* path - Path to point logrotate to for the log rotation
+* paths - A list of paths to point logrotate to for the log rotation.
+* options - List of directives for logrotate, view the logrotate man page for specifics
+* scripts - Dict of scripts for logrotate (see Example below)
+
+```
+logrotate_scripts:
+  - name: rails
+    path: "/srv/current/log/*.log"
+    options:
+      - weekly
+      - size 25M
+      - missingok
+      - compress
+      - delaycompress
+      - copytruncate
+```
+
+```
+logrotate_scripts:
+  - name: rails
+    paths:
+        - "/srv/current/scare.log"
+        - "/srv/current/hide.log"
+    options:
+      - weekly
+      - size 25M
+      - missingok
+      - compress
+      - delaycompress
+      - copytruncate
+```
+
+## Dependencies
+
+None
+
+## Example Playbook
+
+Setting up logrotate for additional Nginx logs, with postrotate script.
+
+```
+- hosts: all
+  vars:
+    logrotate_scripts:
+      - name: nginx-options
+        path: /var/log/nginx/options.log
+        options:
+          - daily
+          - weekly
+          - size 25M
+          - rotate 7
+          - missingok
+          - compress
+          - delaycompress
+          - copytruncate
+
+      - name: nginx-scripts
+        path: /var/log/nginx/scripts.log
+        options:
+          - daily
+          - weekly
+          - size 25M
+        scripts:
+          postrotate: "echo test"
+
+  roles:
+    - ansible-logrotate
+```
+
+## Testing locally
+
+This role is already configured to run on travis CI within a test playbook but it's useful to be able to run and debug a role locally which can be done via Vagrant and the `ansible_local` provisioner.
+
+To run the test playbook locally within a Vagrant virtual machine:
+
+```
+cd tests
+vagrant up --provision
+```
+
+## License
+
+[BSD](https://raw.githubusercontent.com/nickhammond/logrotate/master/LICENSE)
+
+## Author Information
+
+* [nickhammond](https://github.com/nickhammond) | [www](http://www.nickhammond.com) | [twitter](http://twitter.com/nickhammond)
+* [bigjust](https://github.com/bigjust)
+* [steenzout](https://github.com/steenzout)
+* [jeancornic](https://github.com/jeancornic)
+* [duhast](https://github.com/duhast)
+* [kagux](https://github.com/kagux)

--- a/vendor/nickhammond.logrotate/defaults/main.yml
+++ b/vendor/nickhammond.logrotate/defaults/main.yml
@@ -1,0 +1,2 @@
+logrotate_conf_dir: "/etc/logrotate.d/"
+logrotate_scripts: []

--- a/vendor/nickhammond.logrotate/meta/.galaxy_install_info
+++ b/vendor/nickhammond.logrotate/meta/.galaxy_install_info
@@ -1,0 +1,1 @@
+{install_date: 'Tue Jul 24 15:32:02 2018', version: master}

--- a/vendor/nickhammond.logrotate/meta/main.yml
+++ b/vendor/nickhammond.logrotate/meta/main.yml
@@ -1,0 +1,18 @@
+---
+galaxy_info:
+  author: Nick Hammond
+  description: Role to configure logrotate scripts
+  license: BSD
+  min_ansible_version: 1.9
+  platforms:
+  - name: Ubuntu
+    versions:
+    - lucid
+    - precise
+    - trusty
+  - name: EL
+    versions:
+    - 7
+  categories:
+  - system
+dependencies: []

--- a/vendor/nickhammond.logrotate/tasks/main.yml
+++ b/vendor/nickhammond.logrotate/tasks/main.yml
@@ -1,0 +1,13 @@
+---
+- name: nickhammond.logrotate | Install logrotate
+  package:
+    name: logrotate
+    state: present
+  when: logrotate_scripts is defined and logrotate_scripts|length > 0
+
+- name: nickhammond.logrotate | Setup logrotate.d scripts
+  template:
+    src: logrotate.d.j2
+    dest: "{{ logrotate_conf_dir }}{{ item.name }}"
+  with_items: "{{ logrotate_scripts }}"
+  when: logrotate_scripts is defined

--- a/vendor/nickhammond.logrotate/templates/logrotate.d.j2
+++ b/vendor/nickhammond.logrotate/templates/logrotate.d.j2
@@ -1,0 +1,23 @@
+# {{ ansible_managed }}
+
+{% if 'path' in item %}
+"{{ item.path }}"
+{% elif 'paths' in item %}
+{% for path in item.paths %}
+"{{ path }}"
+{% endfor %}
+{% endif %}
+{
+  {% if item.options is defined -%}
+  {% for option in item.options -%}
+  {{ option }}
+  {% endfor -%}
+  {% endif %}
+  {%- if item.scripts is defined -%}
+  {%- for name, script in item.scripts.items() -%}
+  {{ name }}
+    {{ script }}
+  endscript
+  {% endfor -%}
+  {% endif -%}
+}

--- a/vendor/nickhammond.logrotate/tests/Vagrantfile
+++ b/vendor/nickhammond.logrotate/tests/Vagrantfile
@@ -1,0 +1,18 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+@ansible_home = "/home/vagrant/.ansible"
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "ubuntu/trusty64"
+
+  # Copy the Ansible playbook over to the guest machine, run rsync-auto to automatically
+  # pull in the latest changes while a VM is running.
+  config.vm.synced_folder "../", "#{@ansible_home}/roles/ansible-logrotate", type: 'rsync'
+
+  # The working ansible directory created by ansible_local is owned by root
+  config.vm.provision "shell", inline: "chown vagrant:vagrant #{@ansible_home}"
+
+  config.vm.provision "ansible_local" do |ansible|
+    ansible.playbook = "test.yml"
+  end
+end

--- a/vendor/nickhammond.logrotate/tests/inventory
+++ b/vendor/nickhammond.logrotate/tests/inventory
@@ -1,0 +1,1 @@
+localhost

--- a/vendor/nickhammond.logrotate/tests/test.yml
+++ b/vendor/nickhammond.logrotate/tests/test.yml
@@ -1,0 +1,29 @@
+---
+- hosts: all
+  become: True
+  vars:
+    logrotate_scripts:
+      - name: nginx-options
+        path: /var/log/nginx/options.log
+        options:
+          - daily
+
+      - name: nginx-scripts
+        path: /var/log/nginx/scripts.log
+        scripts:
+          postrotate: "echo test"
+
+      - name: multiple-paths
+        paths:
+          - /var/log/nginx/options.log
+          - /var/log/nginx/scripts.log
+
+  roles:
+    - ansible-logrotate
+
+  tasks:
+    - name: Verify logrotate config check passes
+      shell: logrotate -d "{{ logrotate_conf_dir }}{{ item.name }}"
+      with_items: "{{ logrotate_scripts }}"
+      register: logrotate_tests
+      failed_when: "'error' in logrotate_tests.stderr"


### PR DESCRIPTION
### Why?
- Without logrotate, logs fill up the server
- We've used this role on several projects, so it should be integrated into taperole itself

### What changed?
- Added `nickhammond.logrotate` to the `requirements.yml`
- Ran `ansible-galaxy install -r requirements.yml` to install it
- Added the configs for logrotate for our projects 